### PR TITLE
new release: updating build process for new Rust release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ futures-util = "0.3.29"
 [lib]
 name = "surrealml"
 path = "src/lib.rs"
+
+[build-dependencies]
+ort = { version = "1.16.2", default-features = true }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+use std::env;
+
+
+fn main() {
+    let target_lib = match env::var("CARGO_CFG_TARGET_OS").unwrap() {
+        ref s if s.contains("linux") => "libonnxruntime.so",
+        ref s if s.contains("macos") => "libonnxruntime.dylib",
+        ref s if s.contains("windows") => "onnxruntime.dll",
+        // ref s if s.contains("android") => "android", => not building for android
+        _ => panic!("Unsupported target os")
+    };
+    let profile = match env::var("PROFILE").unwrap() {
+        ref s if s.contains("release") => "release",
+        ref s if s.contains("debug") => "debug",
+        _ => panic!("Unsupported profile")
+    };
+
+    // remove ./modules/utils/target folder if there
+    let _ = std::fs::remove_dir_all(Path::new("modules").join("utils").join("target")).unwrap_or(());
+
+    // create the target module folder for the utils module
+    let _ = std::fs::create_dir(Path::new("modules").join("utils").join("target"));
+    let _ = std::fs::create_dir(Path::new("modules").join("utils").join("target").join(profile));
+
+    // copy target folder to modules/utils/target profile for the utils modules
+    std::fs::copy(
+        Path::new("target").join(profile).join(target_lib), 
+        Path::new("modules").join("utils").join("target").join(profile).join(target_lib)
+    ).unwrap();
+}

--- a/modules/utils/.gitignore
+++ b/modules/utils/.gitignore
@@ -1,3 +1,6 @@
 onnx_driver/
 target/
 output/
+downloaded_onnx_package/
+src/execution/libonnxruntime.a
+libonnxruntime.*

--- a/modules/utils/Cargo.toml
+++ b/modules/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "surrealml-core"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 build = "./build.rs"
 description = "The core machine learning library for SurrealML that enables SurrealDB to store and load ML models"
@@ -23,3 +23,6 @@ tokio = { version = "1.12.0", features = ["full"] }
 [lib]
 name = "surrealml_core"
 path = "src/lib.rs"
+
+[build-dependencies]
+ort = { version = "1.16.2", default-features = true }


### PR DESCRIPTION
Due to the new release of rust, the way in which some of the files were stored in different directories which broke the embedding of the ONNX. This pull request fixes this by getting `ort` to download and compile ONNX for the specific platform in `dev-dependencies` and this compiled ONNX library is then embedded.