### PR TITLE
adding glue module to enable error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+workspace = { members = ["modules/glue"] }
 [package]
 name = "surrealml"
 version = "0.1.0"

--- a/modules/core/Cargo.toml
+++ b/modules/core/Cargo.toml
@@ -16,6 +16,7 @@ once_cell = "1.18.0"
 bytes = "1.5.0"
 futures-util = "0.3.28"
 futures-core = "0.3.28"
+glue = { path = "../glue" }
 
 [dev-dependencies]
 tokio = { version = "1.12.0", features = ["full"] }

--- a/modules/core/src/storage/header/keys.rs
+++ b/modules/core/src/storage/header/keys.rs
@@ -1,5 +1,9 @@
 //! Defines the key bindings for input data.
 use std::collections::HashMap;
+use glue::{
+    errors::error::{SurrealError, SurrealErrorStatus}, 
+    safe_eject_internal
+};
 
 
 /// Defines the key bindings for input data.
@@ -46,9 +50,9 @@ impl KeyBindings {
     /// 
     /// # Returns
     /// The key bindings constructed from the string.
-    pub fn from_string(data: String) -> Result<Self, String> {
+    pub fn from_string(data: String) -> Self {
         if data.len() == 0 {
-            return Ok(KeyBindings::fresh())
+            return KeyBindings::fresh()
         }
         let mut store = Vec::new();
         let mut reference = HashMap::new();
@@ -61,11 +65,10 @@ impl KeyBindings {
             reference.insert(line.to_string(), count);
             count += 1;
         }
-
-        Ok(KeyBindings {
+        KeyBindings {
             store,
             reference,
-        })
+        }
     }
 
     /// converts the key bindings to a string.
@@ -83,12 +86,9 @@ impl KeyBindings {
     /// 
     /// # Returns
     /// The key bindings constructed from the bytes.
-    pub fn from_bytes(data: &[u8]) -> Result<Self, String> {
-        let data = match String::from_utf8(data.to_vec()) {
-            Ok(data) => data,
-            Err(_) => return Err("Error converting bytes to string for key bindings".to_string())
-        };
-        Self::from_string(data)
+    pub fn from_bytes(data: &[u8]) -> Result<Self, SurrealError> {
+        let data = safe_eject_internal!(String::from_utf8(data.to_vec()));
+        Ok(Self::from_string(data))
     }
 
     /// Converts the key bindings to bytes.
@@ -135,7 +135,7 @@ pub mod tests {
     #[test]
     fn test_from_string_with_empty_string() {
         let data = "".to_string();
-        let bindings = KeyBindings::from_string(data).unwrap();
+        let bindings = KeyBindings::from_string(data);
         assert_eq!(bindings.store.len(), 0);
         assert_eq!(bindings.reference.len(), 0);
     }
@@ -143,7 +143,7 @@ pub mod tests {
     #[test]
     fn test_from_string() {
         let data = generate_string();
-        let bindings = KeyBindings::from_string(data).unwrap();
+        let bindings = KeyBindings::from_string(data);
         assert_eq!(bindings.store[0], "a");
         assert_eq!(bindings.store[1], "b");
         assert_eq!(bindings.store[2], "c");

--- a/modules/core/src/storage/header/normalisers/utils.rs
+++ b/modules/core/src/storage/header/normalisers/utils.rs
@@ -1,14 +1,20 @@
 //! Utility functions for normalisers to reduce code duplication in areas that cannot be easily defined in a struct.
-use regex::Regex;
+use regex::{Regex, Captures};
+use glue::{
+    safe_eject_option,
+    safe_eject_internal,
+    errors::error::{SurrealError, SurrealErrorStatus}
+};
 
 
 /// Extracts the label from a normaliser string.
 /// 
 /// # Arguments
 /// * `data` - A string containing the normaliser data.
-pub fn extract_label(data: &String) -> String {
-    let re = Regex::new(r"^(.*?)\(").unwrap();
-    re.captures(data).unwrap().get(1).unwrap().as_str().to_string()
+pub fn extract_label(data: &String) -> Result<String, SurrealError> {
+    let re: Regex = safe_eject_internal!(Regex::new(r"^(.*?)\("));
+    let captures: Captures = safe_eject_option!(re.captures(data));
+    Ok(safe_eject_option!(captures.get(1)).as_str().to_string())
 }
 
 
@@ -19,14 +25,17 @@ pub fn extract_label(data: &String) -> String {
 /// 
 /// # Returns
 /// [number1, number2] from `"(number1, number2)"`
-pub fn extract_two_numbers(data: &String) -> [f32; 2] {
-    let re = Regex::new(r"[-+]?\d+(\.\d+)?").unwrap();
+pub fn extract_two_numbers(data: &String) -> Result<[f32; 2], SurrealError> {
+    let re: Regex = safe_eject_internal!(Regex::new(r"[-+]?\d+(\.\d+)?"));
     let mut numbers = re.find_iter(data);
     let mut buffer: [f32; 2] = [0.0, 0.0];
 
-    buffer[0] = numbers.next().unwrap().as_str().parse::<f32>().unwrap();
-    buffer[1] = numbers.next().unwrap().as_str().parse::<f32>().unwrap();
-    buffer
+    let num_one_str = safe_eject_option!(numbers.next()).as_str();
+    let num_two_str = safe_eject_option!(numbers.next()).as_str();
+
+    buffer[0] = safe_eject_internal!(num_one_str.parse::<f32>());
+    buffer[1] = safe_eject_internal!(num_two_str.parse::<f32>());
+    Ok(buffer)
 }
 
 
@@ -38,12 +47,12 @@ mod tests {
     #[test]
     fn test_extract_two_numbers() {
         let data = "linear_scaling(0.0,1.0)".to_string();
-        let numbers = extract_two_numbers(&data);
+        let numbers = extract_two_numbers(&data).unwrap();
         assert_eq!(numbers[0], 0.0);
         assert_eq!(numbers[1], 1.0);
 
         let data = "linear_scaling(0,1)".to_string();
-        let numbers = extract_two_numbers(&data);
+        let numbers = extract_two_numbers(&data).unwrap();
         assert_eq!(numbers[0], 0.0);
         assert_eq!(numbers[1], 1.0);
     }
@@ -51,7 +60,7 @@ mod tests {
     #[test]
     fn test_extract_label() {
         let data = "linear_scaling(0.0,1.0)".to_string();
-        let label = extract_label(&data);
+        let label = extract_label(&data).unwrap();
         assert_eq!(label, "linear_scaling");
     }
 }

--- a/modules/core/src/storage/header/version.rs
+++ b/modules/core/src/storage/header/version.rs
@@ -1,4 +1,12 @@
 //! Defines the process of managing the version of the `surml` file in the file.
+use glue::{
+    safe_eject_option,
+    safe_eject,
+    errors::error::{
+        SurrealError,
+        SurrealErrorStatus
+    }
+};
 
 
 /// The `Version` struct represents the version of the `surml` file.
@@ -47,19 +55,20 @@ impl Version {
     /// 
     /// # Returns
     /// A new `Version` struct.
-    pub fn from_string(version: String) -> Self {
+    pub fn from_string(version: String) -> Result<Self, SurrealError> {
         if version == "".to_string() {
-            return Version::fresh();
+            return Ok(Version::fresh())
         }
         let mut split = version.split(".");
-        let one = split.next().unwrap().parse::<u8>().unwrap();
-        let two = split.next().unwrap().parse::<u8>().unwrap();
-        let three = split.next().unwrap().parse::<u8>().unwrap();
-        Version {
-            one,
-            two,
-            three,
-        }
+        let one_str = safe_eject_option!(split.next());
+        let two_str = safe_eject_option!(split.next());
+        let three_str = safe_eject_option!(split.next());
+
+        Ok(Version {
+            one: safe_eject!(one_str.parse::<u8>(), SurrealErrorStatus::BadRequest),
+            two: safe_eject!(two_str.parse::<u8>(), SurrealErrorStatus::BadRequest),
+            three: safe_eject!(three_str.parse::<u8>(), SurrealErrorStatus::BadRequest),
+        })
     }
 
     /// Increments the version by one.
@@ -84,12 +93,12 @@ pub mod tests {
 
     #[test]
     fn test_from_string() {
-        let version = Version::from_string("0.0.0".to_string());
+        let version = Version::from_string("0.0.0".to_string()).unwrap();
         assert_eq!(version.one, 0);
         assert_eq!(version.two, 0);
         assert_eq!(version.three, 0);
 
-        let version = Version::from_string("1.2.3".to_string());
+        let version = Version::from_string("1.2.3".to_string()).unwrap();
         assert_eq!(version.one, 1);
         assert_eq!(version.two, 2);
         assert_eq!(version.three, 3);

--- a/modules/core/src/storage/stream_adapter.rs
+++ b/modules/core/src/storage/stream_adapter.rs
@@ -7,6 +7,13 @@ use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 use std::pin::Pin;
 use std::error::Error;
+use glue::{
+    safe_eject,
+    errors::error::{
+        SurrealError,
+        SurrealErrorStatus
+    }
+};
 
 
 /// Stream adapter for file system.
@@ -29,12 +36,12 @@ impl StreamAdapter {
     /// 
     /// # Returns
     /// A new `StreamAdapter` struct.
-    pub fn new(chunk_size: usize, file_path: String) -> Self {
-        let file_pointer = File::open(file_path).unwrap();
-        StreamAdapter {
+    pub fn new(chunk_size: usize, file_path: String) -> Result<Self, SurrealError> {
+        let file_pointer = safe_eject!(File::open(file_path), SurrealErrorStatus::NotFound);
+        Ok(StreamAdapter {
             chunk_size,
             file_pointer
-        }
+        })
     }
 
 }

--- a/modules/core/src/storage/surml_file.rs
+++ b/modules/core/src/storage/surml_file.rs
@@ -1,8 +1,16 @@
 //! Defines the saving and loading of the entire `surml` file.
 use std::fs::File;
-use std::io::{self, Read, Write};
+use std::io::{Read, Write};
 
 use crate::storage::header::Header;
+use glue::{
+    safe_eject_internal,
+    safe_eject,
+    errors::error::{
+        SurrealError,
+        SurrealErrorStatus
+    }
+};
 
 
 /// The `SurMlFile` struct represents the entire `surml` file.
@@ -54,10 +62,15 @@ impl SurMlFile {
     /// 
     /// # Returns
     /// A new `SurMlFile` struct.
-    pub fn from_bytes(bytes: Vec<u8>) -> io::Result<Self> {
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, SurrealError> {
         // check to see if there is enough bytes to read
         if bytes.len() < 4 {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "Not enough bytes to read"));
+            return Err(
+                SurrealError::new(
+                    "Not enough bytes to read".to_string(),
+                    SurrealErrorStatus::BadRequest
+                )
+            );
         }
         let mut header_bytes = Vec::new();
         let mut model_bytes = Vec::new();
@@ -89,26 +102,26 @@ impl SurMlFile {
     /// 
     /// # Returns
     /// A new `SurMlFile` struct.
-    pub fn from_file(file_path: &str) -> io::Result<Self> {
-        let mut file = File::open(file_path)?;
+    pub fn from_file(file_path: &str) -> Result<Self, SurrealError> {
+        let mut file = safe_eject!(File::open(file_path), SurrealErrorStatus::NotFound);
 
         // extract the first 4 bytes as an integer to get the length of the header
         let mut buffer = [0u8; 4];
-        file.read_exact(&mut buffer)?;
+        safe_eject!(file.read_exact(&mut buffer), SurrealErrorStatus::BadRequest);
         let integer_value = u32::from_be_bytes(buffer);
 
         // Read the next integer_value bytes for the header
         let mut header_buffer = vec![0u8; integer_value as usize];
-        file.read_exact(&mut header_buffer)?;
+        safe_eject!(file.read_exact(&mut header_buffer), SurrealErrorStatus::BadRequest);
 
         // Create a Vec<u8> to store the data
         let mut model_buffer = Vec::new();
 
         // Read the rest of the file into the buffer
-        file.take(usize::MAX as u64).read_to_end(&mut model_buffer)?;
+        safe_eject!(file.take(usize::MAX as u64).read_to_end(&mut model_buffer), SurrealErrorStatus::BadRequest);
 
         // construct the header and C model from the bytes
-        let header = Header::from_bytes(header_buffer).unwrap();
+        let header = Header::from_bytes(header_buffer)?;
         Ok(Self {
             header,
             model: model_buffer,
@@ -139,12 +152,12 @@ impl SurMlFile {
     /// 
     /// # Returns
     /// An `io::Result` indicating whether the write was successful.
-    pub fn write(&self, file_path: &str) -> io::Result<()> {
+    pub fn write(&self, file_path: &str) -> Result<(), SurrealError> {
         let combined_vec = self.to_bytes();
 
         // write the bytes to a file
-        let mut file = File::create(file_path)?;
-        file.write(&combined_vec)?;
+        let mut file = safe_eject_internal!(File::create(file_path));
+        safe_eject_internal!(file.write(&combined_vec));
         Ok(())
     }
 }
@@ -196,7 +209,7 @@ mod tests {
         match SurMlFile::from_bytes(bytes) {
             Ok(_) => assert!(false),
             Err(error) => {
-                assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+                assert_eq!(error.status, SurrealErrorStatus::BadRequest);
                 assert_eq!(error.to_string(), "Not enough bytes to read");
             }
         }

--- a/modules/glue/Cargo.toml
+++ b/modules/glue/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "glue"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+axum-feature = ["axum"]
+actix-feature = ["actix-web"]
+default = ["actix-feature", "axum-feature"]
+
+[dependencies]
+serde = { version = "1.0.197", features = ["derive"] }
+thiserror = "1.0.57"
+axum = { version = "0.7.4", optional = true }
+actix-web = { version = "4.5.1", optional = true }

--- a/modules/glue/README.md
+++ b/modules/glue/README.md
@@ -1,0 +1,4 @@
+# Glue
+In this crate we define the glue code between the different modules. This saves developers having to repeat themselves and also
+will enable developers to glue two two modules together. For instance, if both modules have functions that return the same errors
+from the `glue` crate, then functions from both of these modules will be able to return the same error and use the `?` operator.

--- a/modules/glue/src/errors/actix.rs
+++ b/modules/glue/src/errors/actix.rs
@@ -1,0 +1,57 @@
+//! Implements the `ResponseError` trait for the `SurrealError` type for the `actix_web` web framework.
+use actix_web::{HttpResponse, error::ResponseError, http::StatusCode};
+pub use crate::errors::error::{SurrealErrorStatus, SurrealError};
+
+
+impl ResponseError for SurrealError {
+    
+    /// Yields the status code for the error.
+    /// 
+    /// # Returns
+    /// * `StatusCode` - The status code for the error.
+    fn status_code(&self) -> StatusCode {
+        match self.status {
+            SurrealErrorStatus::NotFound  => StatusCode::NOT_FOUND,
+            SurrealErrorStatus::Forbidden => StatusCode::FORBIDDEN,
+            SurrealErrorStatus::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
+            SurrealErrorStatus::BadRequest => StatusCode::BAD_REQUEST,
+            SurrealErrorStatus::Conflict => StatusCode::CONFLICT,
+            SurrealErrorStatus::Unauthorized => StatusCode::UNAUTHORIZED
+        }
+    }
+
+    /// Constructs a HTTP response for the error.
+    /// 
+    /// # Returns
+    /// * `HttpResponse` - The HTTP response for the error.
+    fn error_response(&self) -> HttpResponse {
+        let status_code = self.status_code();
+        HttpResponse::build(status_code).json(self.message.clone())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::StatusCode;
+
+    #[test]
+    fn test_status_code() {
+        let error = SurrealError {
+            message: "Test".to_string(),
+            status: SurrealErrorStatus::NotFound
+        };
+        assert_eq!(error.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_error_response() {
+        let error = SurrealError {
+            message: "Test".to_string(),
+            status: SurrealErrorStatus::NotFound
+        };
+        let response = error.error_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/modules/glue/src/errors/axum.rs
+++ b/modules/glue/src/errors/axum.rs
@@ -1,0 +1,44 @@
+//! Implements the `IntoResponse` trait for the `SurrealError` type for the `axum` web framework.
+use axum::response::{IntoResponse, Response};
+use axum::body::Body;
+pub use crate::errors::error::{SurrealErrorStatus, SurrealError};
+
+
+impl IntoResponse for SurrealError {
+    
+    /// Constructs a HTTP response for the error.
+    /// 
+    /// # Returns
+    /// * `Response` - The HTTP response for the error.
+    fn into_response(self) -> Response {
+        let status_code = match self.status {
+            SurrealErrorStatus::NotFound  => axum::http::StatusCode::NOT_FOUND,
+            SurrealErrorStatus::Forbidden => axum::http::StatusCode::FORBIDDEN,
+            SurrealErrorStatus::Unknown => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            SurrealErrorStatus::BadRequest => axum::http::StatusCode::BAD_REQUEST,
+            SurrealErrorStatus::Conflict => axum::http::StatusCode::CONFLICT,
+            SurrealErrorStatus::Unauthorized => axum::http::StatusCode::UNAUTHORIZED
+        };
+        axum::http::Response::builder()
+            .status(status_code)
+            .body(Body::new(self.message))
+            .unwrap()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn test_into_response() {
+        let error = SurrealError {
+            message: "Test".to_string(),
+            status: SurrealErrorStatus::NotFound
+        };
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/modules/glue/src/errors/error.rs
+++ b/modules/glue/src/errors/error.rs
@@ -1,0 +1,101 @@
+//! Custom error that can be attached to a web framework to automcatically result in a http response,
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use std::fmt;
+
+
+#[macro_export]
+macro_rules! safe_eject {
+    // Match when the optional string is provided
+    ($e:expr, $err_status:expr, $msg:expr) => {
+        $e.map_err(|x| {let file_track = format!("{}:{}", file!(), line!()); let formatted_error = format!("{} => {}", file_track, x.to_string()); SurrealError::new(formatted_error, $err_status)})?
+    };
+    // Match when the optional string is not provided
+    ($e:expr, $err_status:expr) => {
+        $e.map_err(|x| {let file_track = format!("{}:{}", file!(), line!()); let formatted_error = format!("{} => {}", file_track, x.to_string()); SurrealError::new(formatted_error, $err_status)})?
+    };
+}
+
+
+#[macro_export]
+macro_rules! safe_eject_internal {
+    // Match when the optional string is provided
+    ($e:expr, $err_status:expr, $msg:expr) => {
+        $e.map_err(|x| {let file_track = format!("{}:{}", file!(), line!()); let formatted_error = format!("{} => {}", file_track, x.to_string()); SurrealError::new(formatted_error, SurrealErrorStatus::Unknown)})?
+    };
+    // Match when the optional string is not provided
+    ($e:expr) => {
+        $e.map_err(|x| {let file_track = format!("{}:{}", file!(), line!()); let formatted_error = format!("{} => {}", file_track, x.to_string()); SurrealError::new(formatted_error, SurrealErrorStatus::Unknown)})?
+    };
+}
+
+
+#[macro_export]
+macro_rules! safe_eject_option {
+    ($check:expr) => {
+        match $check {Some(x) => x, None => {let file_track = format!("{}:{}", file!(), line!());let message = format!("{}=>The value is not found", file_track);return Err(SurrealError::new(message, SurrealErrorStatus::NotFound))}}
+    };
+}
+
+
+/// The status of the custom error.
+/// 
+/// # Fields
+/// * `NotFound` - The request was not found.
+/// * `Forbidden` - You are forbidden to access.
+/// * `Unknown` - An unknown internal error occurred.
+/// * `BadRequest` - The request was bad.
+/// * `Conflict` - The request conflicted with the current state of the server.
+#[derive(Error, Debug, Serialize, Deserialize, PartialEq)]
+pub enum SurrealErrorStatus {
+    #[error("not found")]
+    NotFound,
+    #[error("You are forbidden to access resource")]
+    Forbidden,
+    #[error("Unknown Internal Error")]
+    Unknown,
+    #[error("Bad Request")]
+    BadRequest,
+    #[error("Conflict")]
+    Conflict,
+    #[error("Unauthorized")]
+    Unauthorized
+}
+
+
+/// The custom error that the web framework will construct into a HTTP response.
+/// 
+/// # Fields
+/// * `message` - The message of the error.
+/// * `status` - The status of the error.
+#[derive(Serialize, Deserialize, Debug, Error)]
+pub struct SurrealError {
+    pub message: String,
+    pub status: SurrealErrorStatus
+}
+
+
+impl SurrealError {
+
+    /// Create a new custom error.
+    /// 
+    /// # Arguments
+    /// * `message` - The message of the error.
+    /// * `status` - The status of the error.
+    /// 
+    /// # Returns
+    /// A new custom error.
+    pub fn new(message: String, status: SurrealErrorStatus) -> Self {
+        SurrealError {
+            message,
+            status
+        }
+    }
+}
+
+
+impl fmt::Display for SurrealError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}

--- a/modules/glue/src/errors/mod.rs
+++ b/modules/glue/src/errors/mod.rs
@@ -1,0 +1,7 @@
+pub mod error;
+
+#[cfg(feature = "actix-feature")]
+pub mod actix;
+
+#[cfg(feature = "axum-feature")]
+pub mod axum;

--- a/modules/glue/src/lib.rs
+++ b/modules/glue/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod errors;

--- a/src/python_apis/storage.rs
+++ b/src/python_apis/storage.rs
@@ -250,7 +250,7 @@ pub fn upload_model(
 ) -> Result<(), std::io::Error> {
     let client = Client::new();
     let uri: Uri = url.parse().map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-    let generator = StreamAdapter::new(chunk_size, file_path);
+    let generator = StreamAdapter::new(chunk_size, file_path).unwrap();
     let body = Body::wrap_stream(generator);
 
     let part_req = Request::builder()

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -57,7 +57,7 @@ async fn run_server() {
 async fn send_request(path: &str) {
     let client = Client::new();
     let uri: Uri = "http://0.0.0.0:4000".parse().unwrap();
-    let generator = StreamAdapter::new(5, path.to_string());
+    let generator = StreamAdapter::new(5, path.to_string()).unwrap();
     let body = Body::wrap_stream(generator);
     let req = Request::post(uri).body(body).unwrap();
     let response = client.request(req).await.unwrap();


### PR DESCRIPTION
added a glue module that defines errors that can be constructed into http responses. This enables multiple modules in the repo to all gel together using the `?` operator due to the error handling 