### PR TITLE
Bump skl2onnx in order to pickup ml_dtypes >=0.5

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -190,7 +190,7 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "numpy==1.26.3",
+        "numpy>=2.3",
     ],
     extras_require={
         "dev": [
@@ -200,7 +200,7 @@ setup(
         # If you want to be stricter, bump the lower bounds once you’ve validated.
         "sklearn": [
             "scikit-learn>=1.5",   # NumPy 2–compatible releases
-            "skl2onnx>=1.16.0",
+            "skl2onnx>=1.19.1",
         ],
         "torch": [
             "torch>=2.4",          # reliably NumPy 2–compatible


### PR DESCRIPTION
Before this change I was running into this error:
```
uv run main.py
warning: `VIRTUAL_ENV=/Users/stu/dev/ssttuu/surrealml/venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Traceback (most recent call last):
  File "/Users/stu/dev/ssttuu/surrealml-test/main.py", line 1, in <module>
    import surrealml
  File "/Users/stu/dev/ssttuu/surrealml/clients/python/surrealml/__init__.py", line 1, in <module>
    from surrealml.surml_file import SurMlFile
  File "/Users/stu/dev/ssttuu/surrealml/clients/python/surrealml/surml_file.py", line 6, in <module>
    from surrealml.engine import Engine, SklearnOnnxAdapter, TorchOnnxAdapter, TensorflowOnnxAdapter, OnnxAdapter
  File "/Users/stu/dev/ssttuu/surrealml/clients/python/surrealml/engine/__init__.py", line 3, in <module>
    from surrealml.engine.sklearn import SklearnOnnxAdapter
  File "/Users/stu/dev/ssttuu/surrealml/clients/python/surrealml/engine/sklearn.py", line 5, in <module>
    import skl2onnx
  File "/Users/stu/dev/ssttuu/surrealml-test/.venv/lib/python3.13/site-packages/skl2onnx/__init__.py", line 16, in <module>
    from .convert import convert_sklearn, to_onnx, wrap_as_onnx_mixin
  File "/Users/stu/dev/ssttuu/surrealml-test/.venv/lib/python3.13/site-packages/skl2onnx/convert.py", line 9, in <module>
    from .proto import get_latest_tested_opset_version
  File "/Users/stu/dev/ssttuu/surrealml-test/.venv/lib/python3.13/site-packages/skl2onnx/proto/__init__.py", line 8, in <module>
    from onnx import onnx_pb as onnx_proto
  File "/Users/stu/dev/ssttuu/surrealml-test/.venv/lib/python3.13/site-packages/onnx/__init__.py", line 131, in <module>
    from onnx import (
    ...<12 lines>...
    )
  File "/Users/stu/dev/ssttuu/surrealml-test/.venv/lib/python3.13/site-packages/onnx/compose.py", line 8, in <module>
    from onnx import (
    ...<7 lines>...
    )
  File "/Users/stu/dev/ssttuu/surrealml-test/.venv/lib/python3.13/site-packages/onnx/helper.py", line 21, in <module>
    from onnx import _mapping, defs, subbyte
  File "/Users/stu/dev/ssttuu/surrealml-test/.venv/lib/python3.13/site-packages/onnx/_mapping.py", line 104, in <module>
    np.dtype(ml_dtypes.float4_e2m1fn),
             ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'ml_dtypes' has no attribute 'float4_e2m1fn'. Did you mean: 'float8_e4m3fn'?
```

Now I can successfully depend on surrealml after this bump.