### PR TITLE
Remove unused zip dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "2.0.12"
 onnx-embedding = "0.1.4"
 serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.20.0"
-zip = "4.1.0"
+zip = { version = "4.1.0", default-features = false }
 candle-core = "0.9.1"
 anyhow = "1.0.98"
 candle-nn = "0.9.1"
@@ -87,11 +87,3 @@ inefficient_to_string = "warn"
 # is to the left of the decimal point.
 # https://rust-lang.github.io/rust-clippy/master/#lossy_float_literal
 lossy_float_literal = "warn"
-
-# Checks for functions that are declared `async` but have no `.await`s inside of them.
-# Async functions with no async code create overhead, both mentally and computationally.
-# https://rust-lang.github.io/rust-clippy/master/#unused_async
-#
-# SurrealDB relies on async functions in the AST parser and executor to avoid stack overflows.
-# Warning or denying this lint can cause unexpected errors.
-unused_async = "allow"

--- a/modules/core/Cargo.toml
+++ b/modules/core/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = { workspace = true }
 onnx-embedding = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
-zip = { workspace = true }
+zip = { workspace = true, default-features = false }
 surrealml-tokenizers = { path = "../tokenizers/", optional = true }
 
 [dev-dependencies]

--- a/modules/tokenizers/src/preset_tokenizers.rs
+++ b/modules/tokenizers/src/preset_tokenizers.rs
@@ -14,7 +14,8 @@ const GEMMA_7B: &str = include_str!("../tokenizers/google-gemma-7b-tokenizer.jso
 const GEMMA_2B: &str = include_str!("../tokenizers/google-gemma-2b-tokenizer.json");
 const GEMMA_3_4B_IT: &str = include_str!("../tokenizers/google-gemma-3-4b-it-tokenizer.json");
 const FALCON_7B: &str = include_str!("../tokenizers/tiiuae-falcon-7b-tokenizer.json");
-const BERT_BASE_UNCASED: &str = include_str!("../tokenizers/google-bert-base-uncased-tokenizer.json");
+const BERT_BASE_UNCASED: &str =
+    include_str!("../tokenizers/google-bert-base-uncased-tokenizer.json");
 
 // const MISTRAL_7B_V01: &str =
 //     include_str!("../tokenizers/mistralai-Mistral-7B-v0.1-tokenizer.json");
@@ -24,7 +25,6 @@ const BERT_BASE_UNCASED: &str = include_str!("../tokenizers/google-bert-base-unc
 // const GEMMA_3_4B_IT: &str =
 //     include_str!("../tokenizers/google-gemma-3-4b-it-tokenizer.json");
 // const FALCON_7B: &str = include_str!("../tokenizers/tiiuae-falcon-7b-tokenizer.json");
-
 
 /// Identifiers for the built-in models bundled with this crate.
 ///
@@ -84,7 +84,6 @@ impl fmt::Display for PresetTokenizers {
 }
 
 impl PresetTokenizers {
-
     /// Retrieve the embedded tokenizer identifier for this variant.
     ///
     /// # Returns
@@ -145,7 +144,7 @@ mod tests {
             "google/gemma-2b" => PresetTokenizers::Gemma2B,
             "google/gemma-3-4b-it" => PresetTokenizers::Gemma3_4BIt,
             "tiiuae/falcon-7b" => PresetTokenizers::Falcon7B,
-            "google-bert/bert-base-uncased" => PresetTokenizers::BertBaseUncased
+            "google-bert/bert-base-uncased" => PresetTokenizers::BertBaseUncased,
             "tiiuae/falcon-7b" => PresetTokenizers::Falcon7B
         );
     }


### PR DESCRIPTION
Removes features on the `zip` dependency that are not used.
Removes all the compression library dependencies which aren't actually used.